### PR TITLE
avoid conflict w CNAME in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.sass-cache
+*.css.map
+CNAME


### PR DESCRIPTION
GitHub pages server chokes when there is more than one CNAME file with the same destination. To avoid this, remove the CNAME file from your forked repository. And do not upload it again. Excluding the CNAME file via .gitignore makes sure that you don't add it again. (But you still need to delete it from your fork.)
